### PR TITLE
Update to .NET 9 and C# 13

### DIFF
--- a/DynamicRun/Builder/Compiler.cs
+++ b/DynamicRun/Builder/Compiler.cs
@@ -43,7 +43,7 @@ internal static class Compiler
     private static CSharpCompilation GenerateCode(string sourceCode)
     {
         var codeString = SourceText.From(sourceCode);
-        var options = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp11);
+        var options = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp13);
 
         var parsedSyntaxTree = SyntaxFactory.ParseSyntaxTree(codeString, options);
 

--- a/DynamicRun/Builder/Compiler.cs
+++ b/DynamicRun/Builder/Compiler.cs
@@ -24,12 +24,11 @@ internal static class Compiler
         {
             Console.WriteLine("Compilation done with error.");
 
-            var failures = result.Diagnostics.Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
+            var failures = result.Diagnostics.Where(diagnostic =>
+                diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
 
             foreach (var diagnostic in failures)
-            {
                 Console.Error.WriteLine("{0}: {1}", diagnostic.Id, diagnostic.GetMessage());
-            }
 
             return null;
         }
@@ -53,14 +52,14 @@ internal static class Compiler
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Console).Assembly.Location)
         };
-            
+
         Assembly.GetEntryAssembly()?.GetReferencedAssemblies().ToList()
             .ForEach(a => references.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
 
         return CSharpCompilation.Create("Hello.dll",
-            new[] { parsedSyntaxTree }, 
-            references: references, 
-            options: new CSharpCompilationOptions(OutputKind.ConsoleApplication, 
+            syntaxTrees: [parsedSyntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.ConsoleApplication,
                 optimizationLevel: OptimizationLevel.Release,
                 assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default));
     }

--- a/DynamicRun/Builder/ObservableFileSystemWatcher.cs
+++ b/DynamicRun/Builder/ObservableFileSystemWatcher.cs
@@ -12,8 +12,6 @@ public sealed class ObservableFileSystemWatcher : IDisposable
 {
     private readonly FileSystemWatcher _watcher;
 
-    public IObservable<FileSystemEventArgs> Changed { get; private set; }
-
     /// <summary>
     ///     Pass an existing FileSystemWatcher instance, this is just for the case where it's not possible to only pass the
     ///     configuration, be aware that disposing this wrapper will dispose the FileSystemWatcher instance too.
@@ -24,7 +22,9 @@ public sealed class ObservableFileSystemWatcher : IDisposable
         _watcher = watcher;
 
         Changed = Observable
-            .FromEventPattern<FileSystemEventHandler, FileSystemEventArgs>(h => _watcher.Changed += h, h => _watcher.Changed -= h)
+            .FromEventPattern<FileSystemEventHandler, FileSystemEventArgs>(
+                h => _watcher.Changed += h,
+                h => _watcher.Changed -= h)
             .Select(x => x.EventArgs);
     }
 
@@ -33,14 +33,13 @@ public sealed class ObservableFileSystemWatcher : IDisposable
     ///     the configuration.
     /// </summary>
     public ObservableFileSystemWatcher(Action<FileSystemWatcher> configure)
-        : this(new FileSystemWatcher())
-    {
-        configure(_watcher);
-    }
+        : this(new FileSystemWatcher()) => configure(_watcher);
+
+    public IObservable<FileSystemEventArgs> Changed { get; private set; }
+
+    public void Dispose() => _watcher.Dispose();
 
     public void Start() => _watcher.EnableRaisingEvents = true;
 
     public void Stop() => _watcher.EnableRaisingEvents = false;
-
-    public void Dispose() => _watcher.Dispose();
 }

--- a/DynamicRun/DynamicRun.csproj
+++ b/DynamicRun/DynamicRun.csproj
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.11.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.12.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0"/>
         <PackageReference Include="System.Reactive" Version="6.0.1"/>
     </ItemGroup>
 

--- a/DynamicRun/DynamicRun.csproj
+++ b/DynamicRun/DynamicRun.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>13</LangVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Sources\DynamicProgram.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Sources\DynamicProgram.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Remove="Sources\DynamicProgram.cs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Sources\DynamicProgram.cs">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Reactive" Version="6.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.11.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0"/>
+        <PackageReference Include="System.Reactive" Version="6.0.1"/>
+    </ItemGroup>
 
 </Project>

--- a/DynamicRun/Program.cs
+++ b/DynamicRun/Program.cs
@@ -1,7 +1,7 @@
-﻿using DynamicRun.Builder;
-using System;
+﻿using System;
 using System.IO;
 using System.Reactive.Linq;
+using DynamicRun.Builder;
 
 var sourcesPath = Path.Combine(Environment.CurrentDirectory, "Sources");
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DynamicRun
 
-Dynamically run code using .NET (Core 3.0, Core 3.1, 5, 6, 7 and 8) Roslyn and AssemblyLoadContext
+Dynamically run code using .NET (Core 3.0, Core 3.1, 5, 6, 7, 8 and 9) Roslyn and AssemblyLoadContext
 
 You can read about it on my blog "[Dynamically compile and run code using .NET Core 3.0](https://laurentkempe.com/2019/02/18/dynamically-compile-and-run-code-using-dotNET-Core-3.0/)"
 


### PR DESCRIPTION
This pull request includes several updates to the `DynamicRun` project, focusing on upgrading the .NET framework version, improving code readability, and updating package references.

### Framework and Package Updates:
* Updated the target framework to .NET 9.0 and set the language version to 13 in `DynamicRun/DynamicRun.csproj`.
* Updated package references for `Microsoft.CodeAnalysis.Compilers`, `Microsoft.CodeAnalysis.CSharp`, and `System.Reactive` to newer versions in `DynamicRun/DynamicRun.csproj`.

### Code Readability Improvements:
* Reformatted the lambda expressions in `Compile` and `ObservableFileSystemWatcher` methods to improve readability in `DynamicRun/Builder/Compiler.cs` and `DynamicRun/Builder/ObservableFileSystemWatcher.cs`. [[1]](diffhunk://#diff-e409c6924618d6aaf462c98a9c4cb9f85ae10725c8140029c7a9dc34e636672fL27-L32) [[2]](diffhunk://#diff-82c0dca110b7029375dfbb176396ab362aa28a80ffec5ff39f6ec87f3d587a65L27-R27)
* Moved the `Changed` property and `Dispose` method in `ObservableFileSystemWatcher` to improve code organization in `DynamicRun/Builder/ObservableFileSystemWatcher.cs`.

### Codebase Maintenance:
* Updated the language version used in the `GenerateCode` method to C# 13 in `DynamicRun/Builder/Compiler.cs`.
* Simplified the `CSharpCompilation.Create` method call by using named arguments in `DynamicRun/Builder/Compiler.cs`.

### Documentation Update:
* Updated the `README.md` file to reflect support for .NET 9.0.

### Minor Fixes:
* Adjusted the order of using statements in `DynamicRun/Program.cs` for better organization.